### PR TITLE
Strip invalid HTTP/2 headers

### DIFF
--- a/kong/plugins/azure-functions/handler.lua
+++ b/kong/plugins/azure-functions/handler.lua
@@ -121,11 +121,11 @@ function azure:access(config)
   local response_content = res:read_body()
 
   if var.http2 then
-    response_headers["Connection"] = ""
-    response_headers["Keep-Alive"] = ""
-    response_headers["Proxy-Connection"] = ""
-    response_headers["Upgrade"] = ""
-    response_headers["Transfer-Encoding"] = ""
+    response_headers["Connection"] = nil
+    response_headers["Keep-Alive"] = nil
+    response_headers["Proxy-Connection"] = nil
+    response_headers["Upgrade"] = nil
+    response_headers["Transfer-Encoding"] = nil
   end
 
   ok, err = client:set_keepalive(config.keepalive)

--- a/kong/plugins/azure-functions/handler.lua
+++ b/kong/plugins/azure-functions/handler.lua
@@ -125,9 +125,7 @@ function azure:access(config)
     response_headers["Keep-Alive"] = ""
     response_headers["Proxy-Connection"] = ""
     response_headers["Upgrade"] = ""
-    if response_headers["Transfer-Encoding"] ~= "trailers" then
-      response_headers["Transfer-Encoding"] = ""
-    end
+    response_headers["Transfer-Encoding"] = ""
   end
 
   ok, err = client:set_keepalive(config.keepalive)

--- a/kong/plugins/azure-functions/handler.lua
+++ b/kong/plugins/azure-functions/handler.lua
@@ -32,6 +32,7 @@ end
 
 function azure:access(config)
   azure.super.access(self)
+  local var = ngx.var
 
   -- prepare and store updated config in cache
   local conf = conf_cache[config]
@@ -118,6 +119,16 @@ function azure:access(config)
   local response_headers = res.headers
   local response_status = res.status
   local response_content = res:read_body()
+
+  if var.http2 then
+    response_headers["Connection"] = ""
+    response_headers["Keep-Alive"] = ""
+    response_headers["Proxy-Connection"] = ""
+    response_headers["Upgrade"] = ""
+    if response_headers["Transfer-Encoding"] ~= "trailers" then
+      response_headers["Transfer-Encoding"] = ""
+    end
+  end
 
   ok, err = client:set_keepalive(config.keepalive)
   if not ok then


### PR DESCRIPTION
Per https://tools.ietf.org/html/rfc7540#section-8.1.2.2 intermediaries that proxy HTTP/1.1 responses to HTTP/2 clients should strip certain headers that do not serve any purpose in HTTP/2. Not stripping these
headers results in a protocol violation for RFC-compliant clients.

See similar discussion for aws-lambda at https://github.com/Kong/kong/pull/4032